### PR TITLE
Use redbot.core.commands

### DIFF
--- a/anisearch/anisearch.py
+++ b/anisearch/anisearch.py
@@ -5,7 +5,7 @@ import re
 
 import aiohttp
 import discord
-from discord.ext import commands
+from redbot.core import commands
 
 numbs = {
     "next": "➡",

--- a/sysinfo/sysinfo.py
+++ b/sysinfo/sysinfo.py
@@ -5,7 +5,7 @@ import time
 import socket
 from socket import AF_INET, SOCK_STREAM, SOCK_DGRAM
 
-from discord.ext import commands
+from redbot.core import commands
 from redbot.core import checks
 
 try:


### PR DESCRIPTION
This will prevent this error:

```py
Exception during loading of cog
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/redbot/core/core_commands.py", line 95, in _load
    await bot.load_extension(spec)
  File "/usr/local/lib/python3.6/dist-packages/redbot/core/bot.py", line 228, in load_extension
    lib.setup(self)
  File "/home/laggron42/Red/cogs/CogManager/cogs/sysinfo/__init__.py", line 7, in setup
    bot.add_cog(n)
  File "/usr/local/lib/python3.6/dist-packages/redbot/core/bot.py", line 334, in add_cog
    f"The {cog.__class__.__name__} cog in the {cog.__module__} package,"
RuntimeError: The SysInfo cog in the sysinfo.sysinfo package, is not using Red's command module, and cannot be added. If this is your cog, please use `from redbot.core import commands`in place of `from discord.ext import commands`. For more details on this requirement, see this page: http://red-discordbot.readthedocs.io/en/v3-develop/framework_commands.html
```